### PR TITLE
Add OCR extraction using pytesseract

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,19 @@ This project demonstrates a PyTorch pipeline for detecting the issuing country o
 
 ```bash
 poetry install
-pre-commit install
+ pre-commit install
 ```
+
+### OCR
+
+Text extraction relies on [Tesseract](https://github.com/tesseract-ocr/tesseract).
+Install it using your system package manager, e.g. on Ubuntu:
+
+```bash
+sudo apt-get install tesseract-ocr
+```
+
+pytesseract will be installed automatically with the Python dependencies.
 
 ## Data
 

--- a/passport_recognition/model.py
+++ b/passport_recognition/model.py
@@ -4,7 +4,8 @@ from typing import Optional
 
 import torch
 from torch import nn
-from torchvision import models
+from torchvision import models, transforms as T
+import pytesseract
 from transformers import AutoModel, AutoTokenizer
 
 
@@ -36,5 +37,11 @@ class PassportCountryModel(nn.Module):
         return self.classifier(features)
 
     def extract_text(self, images: torch.Tensor) -> list[str]:
-        # Placeholder for OCR extraction
-        return ["" for _ in range(len(images))]
+        """Extract text from a batch of images using Tesseract OCR."""
+        to_pil = T.ToPILImage()
+        texts = []
+        for img in images:
+            pil_img = to_pil(img.cpu())
+            text = pytesseract.image_to_string(pil_img, lang="eng")
+            texts.append(text)
+        return texts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ Pillow = "*"
 numpy = "*"
 scikit-learn = "*"
 transformers = "*"
+pytesseract = "*"
 
 [tool.poetry.group.dev.dependencies]
 black = "22.3.0"


### PR DESCRIPTION
## Summary
- implement `extract_text` using pytesseract OCR
- document OCR setup in README
- add pytesseract dependency

## Testing
- `black passport_recognition`
- `pytest -q`